### PR TITLE
Use console.error instead of throw

### DIFF
--- a/src/reporter.js
+++ b/src/reporter.js
@@ -6,21 +6,15 @@ export default function (message) {
   const violations = message.violations;
 
   if (violations.length > 0) {
-    let descriptions = [];
-
-    violations.map((violation) => {
-      descriptions.push(violation.help);
-    });
-
     request({
       method: "POST",
       url: url,
       json: message,
     }, function() {});
 
-    throw new Error(
-      `AccessLintError: ${violations.length} violations:` + "\n" +
-      descriptions.join(",\n")
+    console.error(
+      `AccessLint - ${violations.length} accessibility violations:`,
+      violations
     );
   }
 }


### PR DESCRIPTION
- We want the script to continue.
- Console.error supports logging objects.
- Poltergeist will still fail with this implementation.