### PR TITLE
Filter, configure, and log results to console

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "browser": true
+  }
+}

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,5 +1,5 @@
 javascript:
   enabled: false
-jshint:
+eslint:
   enabled: true
-  config_file: .javascript-style.json
+  config_file: .eslintrc

--- a/README.md
+++ b/README.md
@@ -2,30 +2,31 @@
 
 # Accessibility Monitoring for Your Website
 
-AccessLint.js warns you of accessibility errors in your website.
+accesslint.js warns you of accessibility errors in your website.
 
 ## Usage
 
-Install AccessLint.js by including the javascript in at the end of any page you
-want to monitor.
-
-Include the compiled library through the AccessLint CDN:
+Download the compiled library from the releases page or build it yourself. Then,
+include the javascript in you page:
 
 ```
-<script src="https://cdn.accesslint.com/accesslint-0.1.js" type="text/javascript">
+<script src="accesslint.js" type="text/javascript">
 ```
 
 ## How it works
 
 When a visitor arrives at a page that has the script installed, an audit will
 run in the background automatically. If there are any accessibility issues on
-that page, AccessLint.js will raise the error and track it for review.
+that page, accesslint.js will log the error to the console, and post to a server
+endpoint that you can optionally configure.
 
-AccessLint.js runs assertions from the
+accesslint.js runs assertions from the
 [aXe-core](https://github.com/dequelabs/axe-core) accessibility library wherever
-you include the script. It the raises JavaScript errors in the page and posts
-results to the [AccessLint service](https://beta.accesslint.com), where you can
-add reporting and notification integrations.
+you include the script. It the logs the violations the browser's Javascript
+console. It also POSTs the results to `/access_lint/errors` in your app. If you
+set up and endpoint with that path, you can log the errors on the server too.
+See [AccessLint::Rails](https://github.com/thoughtbot/access_lint-rails) for a
+Rails implementation of server side logging of accessibility errors.
 
 ## Development
 
@@ -49,10 +50,3 @@ code for inclusion clientside. It uses karma and mocha to run tests.
 #### Production
 
     $ gulp build
-
-### Deploying
-
-AccessLint.js is hosted on Amazon S3 behind Cloudfront. You must have AWS
-credentials with the AccessLint account to publish an updated version.
-
-    $ gulp publish

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/accesslint/monitor/issues"
   },
   "devDependencies": {
-    "axe-core": "~1.1.0",
+    "axe-core": "~1.1.1",
     "babel-core": "^6.2.1",
     "babel-loader": "^6.2.0",
     "babel-preset-es2015": "^6.1.18",

--- a/src/auditor.js
+++ b/src/auditor.js
@@ -2,13 +2,7 @@ import { axe } from "axe-core/axe.min.js";
 import report from "./reporter";
 
 export default function () {
-  const options = {
-    "rules": {
-      "color-contrast": { enabled: false },
-    }
-  };
-
-  window.axe.a11yCheck(document, options, (results) => {
+  window.axe.a11yCheck(document, {}, (results) => {
     report(results);
   });
 }

--- a/src/auditor.js
+++ b/src/auditor.js
@@ -2,13 +2,6 @@ import { axe } from "axe-core/axe.min.js";
 import report from "./reporter";
 
 export default function () {
-  window.axe.configure({
-    checks: [{
-      id: "color-contrast",
-      options: { noScroll: true }
-    }]
-  });
-
   window.axe.a11yCheck(document, (results) => {
     report(results);
   });

--- a/src/auditor.js
+++ b/src/auditor.js
@@ -2,7 +2,14 @@ import { axe } from "axe-core/axe.min.js";
 import report from "./reporter";
 
 export default function () {
-  window.axe.a11yCheck(document, {}, (results) => {
+  window.axe.configure({
+    checks: [{
+      id: "color-contrast",
+      options: { noScroll: true }
+    }]
+  });
+
+  window.axe.a11yCheck(document, (results) => {
     report(results);
   });
 }

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -3,13 +3,32 @@ import request from "browser-request";
 const url = "/access_lint/errors"
 
 export default function (message) {
-  const violations = message.violations;
+  var violations = message.violations.map(function(violation) {
+    return {
+      description: violation.description,
+      help: violation.help,
+      helpUrl: violation.helpUrl,
+      id: violation.id,
+      nodes: violation.nodes.map(function(n) {
+        return {
+          target: n.target,
+          impact: n.impact
+        };
+      }),
+      tags: violation.tags
+    };
+  });
 
   if (violations.length > 0) {
     request({
       method: "POST",
       url: url,
-      json: message,
+      json: {
+        accesslint: {
+          violations: violations,
+          url: window.location.pathname
+        }
+      }
     }, function() {});
   }
 }

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -12,6 +12,7 @@ export default function (message) {
       nodes: violation.nodes.map(function(n) {
         return {
           target: n.target,
+          html: n.html,
           impact: n.impact
         };
       }),
@@ -31,4 +32,6 @@ export default function (message) {
       }
     }, function() {});
   }
+
+  console.log("AccessLint warnings: ", violations);
 }

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,6 +1,6 @@
 import request from "browser-request";
 
-const url = "https://beta.accesslint.com/api/v1/reports";
+const url = "/access_lint/errors"
 
 export default function (message) {
   const violations = message.violations;
@@ -11,10 +11,5 @@ export default function (message) {
       url: url,
       json: message,
     }, function() {});
-
-    console.error(
-      `AccessLint - ${violations.length} accessibility violations:`,
-      violations
-    );
   }
 }

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,6 +1,6 @@
 import request from "browser-request";
 
-const url = "/access_lint/errors"
+const url = "/access_lint/errors";
 
 export default function (message) {
   var violations = message.violations.map(function(violation) {


### PR DESCRIPTION
- Do not scroll for color contrast checking (for use in development and staging).
- Post to an application endpoint instead of an external url.
- Only report the attributes that will not be null.